### PR TITLE
Support custom hashlists from the user

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+validators
+langchain
+chainlit
+
+[dev-packages]
+
+[requires]
+python_version = "3.12"
+python_full_version = "3.12.1"


### PR DESCRIPTION
Users can specify hashlists by sending the hashes
themselves, providing a URL to where they're hosted, or by uploading a hashlist file directly. The word "hashlist" must appear in the message.